### PR TITLE
add test script and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npm run lint && npm run build"
   },
   "dependencies": {
     "@vercel/analytics": "^0.1.8",


### PR DESCRIPTION
This PR adds an `npm test` command. No real tests yet, but it'll at least tell us whether there's a linting error or a build failure.

This also adds a GitHub Actions workflow to run tests on every PR and on every push to the main branch.