### PR TITLE
Use Replicate deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Find your Replicate API token at https://www.replicate.com/account
 REPLICATE_API_TOKEN=
+
+# Set this to any value if to run from a Replicate deployment instead of a public model
+# USE_REPLICATE_DEPLOYMENT=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.2",
-        "react-spinners": "^0.13.8"
+        "react-spinners": "^0.13.8",
+        "replicate": "^0.20.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.8",
@@ -3065,6 +3066,17 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/replicate": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.20.1.tgz",
+      "integrity": "sha512-QVyI1rowGsSfNuDrRmumYPdCHa/fN/RkI3NHpcK0i5hSSiWK69URAyheAC/0MIAiS3oUs4kD56PB9zEI4oHENw==",
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -5741,6 +5753,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "replicate": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.20.1.tgz",
+      "integrity": "sha512-QVyI1rowGsSfNuDrRmumYPdCHa/fN/RkI3NHpcK0i5hSSiWK69URAyheAC/0MIAiS3oUs4kD56PB9zEI4oHENw=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.2",
-    "react-spinners": "^0.13.8"
+    "react-spinners": "^0.13.8",
+    "replicate": "^0.20.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.8",

--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -1,3 +1,12 @@
+import Replicate from "replicate";
+
+const replicate = new Replicate({
+  auth: process.env.REPLICATE_API_TOKEN,
+  userAgent: `${packageData.name}/${packageData.version}`
+});
+
+
+
 const API_HOST = process.env.REPLICATE_API_HOST || "https://api.replicate.com";
 
 import packageData from "../../../package.json";
@@ -7,38 +16,34 @@ export default async function handler(req, res) {
     throw new Error("The REPLICATE_API_TOKEN environment variable is not set. See README.md for instructions on how to set it.");
   }
   
-  // remnove null and undefined values
+  // remove null and undefined values
   req.body = Object.entries(req.body).reduce(
     (a, [k, v]) => (v == null ? a : ((a[k] = v), a)),
     {}
   );
 
-  const body = JSON.stringify({
+  let prediction
+  if (process.env.USE_REPLICATE_DEPLOYMENT) {
+    console.log("Using deployment")
+    prediction = await replicate.deployments.predictions.create(
+      "replicate",
+      "paint-by-text",
+      {
+        input: req.body
+      }
+    );
+  } else {
+    console.log("Not using deployment")
     // https://replicate.com/timothybrooks/instruct-pix2pix/versions
-    version: "30c1d0b916a6f8efce20493f5d61ee27491ab2a60437c13c588468b9810ec23f",
-    input: req.body,
-  });
-
-  const headers = {
-    Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
-    "Content-Type": "application/json",
-    "User-Agent": `${packageData.name}/${packageData.version}`
+    const version = "30c1d0b916a6f8efce20493f5d61ee27491ab2a60437c13c588468b9810ec23f"
+    prediction = await replicate.predictions.create({
+      version, 
+      input: req.body
+    });
   }
 
-  const response = await fetch(`${API_HOST}/v1/predictions`, {
-    method: "POST",
-    headers,
-    body,
-  });
+  console.log({prediction});
 
-  if (response.status !== 201) {
-    let error = await response.json();
-    res.statusCode = 500;
-    res.end(JSON.stringify({ detail: error.detail }));
-    return;
-  }
-
-  const prediction = await response.json();
   res.statusCode = 201;
   res.end(JSON.stringify(prediction));
 }


### PR DESCRIPTION
This PR updates the app to use [Replicate deployments](https://replicate.com/docs/deployments) so we have more control over the underlying hardware and scaling configuration.

## Tasks

- [x] Swap out REPLICATE_API_TOKEN in Vercel env to use @replicate token instead of @zeke token
- [x] Set USE_REPLICATE_DEPLOYMENT in Vercel env
- [x] Verify that preview Vercel deployment is using Replicate deployments